### PR TITLE
Add Kubernetes Gateway API

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,13 +434,13 @@ kubectl label namespace sample "istio.io/rev=${ISTIO_REVISION}"
 #### on `amd64` host
 
 ```sh
-kubectl apply -n sample -f https://raw.githubusercontent.com/istio/istio/release-1.19/samples/helloworld/helloworld.yaml
+kubectl apply -n sample -f https://raw.githubusercontent.com/istio/istio/release-1.20/samples/helloworld/helloworld.yaml
 ```
 
 #### on `arm64` host
 
 ```sh
-curl --silent https://raw.githubusercontent.com/istio/istio/release-1.19/samples/helloworld/helloworld.yaml \
+curl --silent https://raw.githubusercontent.com/istio/istio/release-1.20/samples/helloworld/helloworld.yaml \
   | sed -E 's!istio/examples!radekg/examples!g' \
   | kubectl apply -n sample -f -
 ```

--- a/install.istio.sh
+++ b/install.istio.sh
@@ -26,7 +26,7 @@ spec:
   components:
     ingressGateways:
     - name: istio-ingressgateway
-      enabled: true
+      enabled: false
     - name: istio-csr-ingressgateway
       enabled: true
       k8s:

--- a/install.k3s.sh
+++ b/install.k3s.sh
@@ -47,3 +47,17 @@ multipass exec k3s-master sudo cat /etc/rancher/k3s/k3s.yaml > "${KUBECONFIG}"
 # Update the IP address to the one mapped by multipass
 sed -i '' "s/127.0.0.1/${MASTER_IP}/" "${KUBECONFIG}"
 chmod 600 "${KUBECONFIG}"
+
+# Install Gateway API CRSs:
+# -------------------------
+# These do not come installed by default but when enabled, Istio will configure itself with
+# two GatewayClass resources:
+# 
+# $ kubectl get gatewayclass -A
+# NAME           CONTROLLER                    ACCEPTED   AGE
+# istio-remote   istio.io/unmanaged-gateway    True       44s
+# istio          istio.io/gateway-controller   True       44s
+# 
+# Experimental because we need TLSRoute, TCPRoute.
+# Reference: https://gateway-api.sigs.k8s.io/guides/#install-experimental-channel.
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.0.0/experimental-install.yaml


### PR DESCRIPTION
Disables the default Istio ingrss gateway with the intent of using Kubernetes Gateway API as the ingress method.  
The VM workload requires an Istio ingress gateway, the _eastwest gateway_, but not the default one.